### PR TITLE
fix: accept nil as valid config table

### DIFF
--- a/lua/lasso/init.lua
+++ b/lua/lasso/init.lua
@@ -5,6 +5,8 @@ local config = {}
 
 
 function M.setup(config_)
+    config_ = config_ or {}
+
     config.marks_tracker_path = config_.marks_tracker_path or '.lasso-marks-tracker'
 end
 

--- a/lua/lasso/init.lua
+++ b/lua/lasso/init.lua
@@ -5,7 +5,9 @@ local config = {}
 
 
 function M.setup(config_)
-    config_ = config_ or {}
+    if config_ == nil then
+        config_ = {}
+    end
 
     config.marks_tracker_path = config_.marks_tracker_path or '.lasso-marks-tracker'
 end


### PR DESCRIPTION
Just a small fix to allow people to setup the plugin without having to pass an empty table if they don't want to configure anything

```lua 
-- allows this
require('lasso').setup()

-- instead of just this
require('lasso').setup({})
```